### PR TITLE
Fix: handle missing gh CLI in cmd_gh using shutil.which

### DIFF
--- a/.speckle/cli.py
+++ b/.speckle/cli.py
@@ -13,6 +13,7 @@ Usage:
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -140,6 +141,12 @@ def cmd_gh(args):
     RESET = '\033[0m'
     DIM = '\033[2m'
     
+    # Check if gh CLI is installed
+    if not shutil.which("gh"):
+        print("Error: GitHub CLI (gh) not installed", file=sys.stderr)
+        print("Install from: https://cli.github.com", file=sys.stderr)
+        return 1
+
     # Fetch issues from GitHub
     cmd = ['gh', 'issue', 'list', '--json', 'number,title,labels,state', '--limit', str(args.limit)]
     if args.all:


### PR DESCRIPTION
## Fix: Handle missing gh CLI gracefully

This PR fixes a crash in `cmd_gh` when the GitHub CLI (`gh`) is not installed.

### Changes
- Added a check using `shutil.which("gh")`
- Prints a clear error message to stderr if `gh` is not installed
- Returns exit code 1 instead of raising `FileNotFoundError`

### Why
Previously, running the command without `gh` installed caused a crash: